### PR TITLE
seller_id and bank_id need to be numeric (code samples)

### DIFF
--- a/samples.md
+++ b/samples.md
@@ -261,8 +261,8 @@ client = SynapsePay::User.login("username", "password")
 order = client.orders.create({
   :amount => "100",
   :facilitator_fee => "1",
-  :seller_id => "3425",
-  :bank_id => "2174"
+  :seller_id => 3425,
+  :bank_id => 2174
 })
 ```
 


### PR DESCRIPTION
otherwise the request will fail but instead of complaining about the data type it will say the bank account is not associated with the user when it is. Changing to a numeric data type, the request completes successfully as it should.
