### PR TITLE
Properly limit exception handling in requests

### DIFF
--- a/lib/synapse_pay/apibits/api_method.rb
+++ b/lib/synapse_pay/apibits/api_method.rb
@@ -26,7 +26,7 @@ module SynapsePay
         response = Requester.request(method, url, params, headers)
         @response_body = response.body
         @response_code = response.code
-      rescue Exception => e
+      rescue RestClient::Exception => e
         @response_body = e.http_body if e.respond_to?(:http_body)
         @response_code = e.http_code if e.respond_to?(:http_code)
         @error = compose_error(e)


### PR DESCRIPTION
Rescuing from `Exception` is bad practice because is rescues EVERYTHING
in that block including `NoMemoryErrors` and `SyntaxErrors`. What this
means in practice is that cannot use gems like `webmock` and `fakeweb`
to test your integration. Limiting to `RestClient::Exception` will
rescue all HTTP-related errors, which is likely the intended behavior.

And alternative suggestion is to rescue `StandardError`, which is best
practice for "rescue everything" since broader issues do not inherit
from `StandardError`.
