### PR TITLE
Simplify development instructions and setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,24 @@
 
 ## Installation
 
-You don't need this source code unless you want to modify the gem. If
-you just want to use the SynapsePay Ruby bindings, you should run:
+Add this line to your Gemfile:
+
+```ruby
+gem 'synapse_pay'
+```
+
+And then execute:
+
+```bash
+bundle install
+```
+
+Or install it yourself as:
 
 ```bash
 gem install synapse_pay
 ```
 
-If you want to build & install the gem from source:
-
-```bash
-gem build synapse_pay.gemspec
-gem install synapse_pay-0.0.8.gem
-```
 
 ## Documentation
 
@@ -30,8 +35,7 @@ See [samples.md](https://github.com/synapsepayments/synapse_pay-ruby/blob/master
 
 ## Requirements
 
-* Ruby 1.8.7 or above. (Ruby 1.8.6 may work if you load
-  ActiveSupport.) For Ruby versions before 1.9.2, you'll need to add this to your Gemfile:
+* Ruby 1.8.7 or above. (Ruby 1.8.6 may work if you load ActiveSupport.) For Ruby versions before 1.9.2, you'll need to add this to your Gemfile:
 
 ```ruby
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('1.9.2')
@@ -42,20 +46,23 @@ end
 * rest-client, json
 
 
-## Bundler
-
-If you are installing via bundler, you should be sure to use the https
-rubygems source in your Gemfile, as any gems fetched over http could potentially be compromised.
-
-```ruby
-source 'https://rubygems.org'
-
-gem 'rails'
-gem 'synapse_pay'
-```
-
-
 ## Development
 
-Test cases can be run with: `bundle exec rake test`
+Clone the repo and install:
 
+```sh
+git clone https://github.com/synapsepayments/synapse_pay-ruby.git
+bundle install
+```
+
+Load the gem in an IRB console:
+
+```sh
+bundle console
+```
+
+Test cases can be run with:
+
+```sh
+bundle exec rake test
+```

--- a/bin/synapse_pay-console
+++ b/bin/synapse_pay-console
@@ -1,7 +1,0 @@
-#!/usr/bin/env ruby
-irb = RUBY_PLATFORM =~ /(:?mswin|mingw)/ ? 'irb.bat' : 'irb'
-
-libs =  " -r irb/completion"
-libs <<  " -r #{File.dirname(__FILE__) + '/../lib/synapse_pay'}"
-puts "Loading SynapsePay gem"
-exec "#{irb} #{libs} --simple-prompt"


### PR DESCRIPTION
I've had the gem setup for development for awhile now. I've been meaning to fix the console script as I had trouble getting it working but didn't occur to me until today that its actually unnecessary (duh) since Bundler already handles this. The installation instructions also weren't very Ruby-gem-ish so I cleared them up a bit with what Rubyists are used too. Since its expected to run `bundle install` in development all you need to do is run `bundle console` to get an IRB console with the gem loaded. Much easier and no errors about other dependencies not being found (e.g. rest_client). If the console script was in for supporting older versions of Ruby I'd seriously consider just dropping support for older Rubies. 1.9.2 was EOL summer last year and 1.9.3 was EOL back in February. Time to move on.
